### PR TITLE
Depend on requests for installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     },
     install_requires=[
         'django',
+        'requests>=2.5.1',
     ],
     description='Bindings and utils for integrating Node.js and NPM into a Django application',
     long_description='Documentation at https://github.com/markfinger/django-node',


### PR DESCRIPTION
`django_node.nodeserver` imports `requests`.

Without this patch, projects that depend directly or indirectly on django-node and use `django_node.nodeserver` will need to add a `requests` requirement to their package.