### PR TITLE
Include required echo service in package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     package_data={
         'django_node': [
             'node_server.js',
+            'services/echo.js',
             'package.json',
         ],
     },


### PR DESCRIPTION
The echo.js file was missing when installed
